### PR TITLE
Use opencv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(argparse REQUIRED)
 find_package(freenect2 REQUIRED)
+find_package(OpenCV REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
@@ -31,7 +32,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 
 ament_target_dependencies(${PROJECT_NAME}
-  argparse freenect2 rclcpp sensor_msgs)
+  argparse freenect2 OpenCV rclcpp sensor_msgs)
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
@@ -57,6 +58,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(argparse freenect2 rclcpp sensor_msgs)
+ament_export_dependencies(argparse freenect2 OpenCV rclcpp sensor_msgs)
 
 ament_package()

--- a/bin/kinect2_node.cpp
+++ b/bin/kinect2_node.cpp
@@ -23,6 +23,7 @@
 #include <kinect2/kinect2.hpp>
 
 #include <memory>
+#include <string>
 
 int main(int argc, char ** argv)
 {
@@ -38,6 +39,16 @@ int main(int argc, char ** argv)
   .default_value(false)
   .implicit_value(true);
 
+  program.add_argument("--width", "-w")
+  .help("width of the published image (negative to use the original width)")
+  .default_value(-1)
+  .action([](const std::string & value) {return std::stoi(value);});
+
+  program.add_argument("--height", "-h")
+  .help("height of the published image (negative to use the original height)")
+  .default_value(-1)
+  .action([](const std::string & value) {return std::stoi(value);});
+
   kinect2::Kinect2::Options kinect2_options;
 
   // Try to parse arguments
@@ -46,6 +57,8 @@ int main(int argc, char ** argv)
 
     kinect2_options.enable_rgb = !program.get<bool>("--disable-rgb");
     kinect2_options.enable_depth = !program.get<bool>("--disable-depth");
+    kinect2_options.width = program.get<int>("--width");
+    kinect2_options.height = program.get<int>("--height");
   } catch (const std::exception & e) {
     std::cout << e.what() << std::endl;
     std::cout << program;

--- a/include/kinect2/kinect2.hpp
+++ b/include/kinect2/kinect2.hpp
@@ -40,6 +40,9 @@ public:
 
     bool enable_rgb;
     bool enable_depth;
+
+    int width;
+    int height;
   };
 
   explicit Kinect2(const Options & options = Options());
@@ -55,6 +58,8 @@ private:
 
   libfreenect2::PacketPipeline * pipeline;
   libfreenect2::Freenect2Device * device;
+
+  Options options;
 };
 
 }  // namespace kinect2

--- a/include/kinect2/utility.hpp
+++ b/include/kinect2/utility.hpp
@@ -34,8 +34,13 @@ namespace kinect2
 cv::Mat frame_to_mat(libfreenect2::Frame * frame, const int & type = CV_8UC3);
 std::shared_ptr<sensor_msgs::msg::Image> mat_to_image(cv::Mat mat);
 
-std::shared_ptr<sensor_msgs::msg::Image> rgb_frame_to_image(libfreenect2::Frame * frame);
-std::shared_ptr<sensor_msgs::msg::Image> ir_frame_to_image(libfreenect2::Frame * frame);
+cv::Mat resize_mat(cv::Mat mat, int width, int height);
+
+std::shared_ptr<sensor_msgs::msg::Image> rgb_frame_to_image(
+  libfreenect2::Frame * frame, const int & width, const int & height);
+
+std::shared_ptr<sensor_msgs::msg::Image> ir_frame_to_image(
+  libfreenect2::Frame * frame, const int & width, const int & height);
 
 }  // namespace kinect2
 

--- a/include/kinect2/utility.hpp
+++ b/include/kinect2/utility.hpp
@@ -22,6 +22,7 @@
 #define KINECT2__UTILITY_HPP_
 
 #include <libfreenect2/frame_listener.hpp>
+#include <opencv2/core.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include <memory>
@@ -30,7 +31,9 @@
 namespace kinect2
 {
 
-std::shared_ptr<sensor_msgs::msg::Image> frame_info_to_image(libfreenect2::Frame * frame);
+cv::Mat frame_to_mat(libfreenect2::Frame * frame, const int & type = CV_8UC3);
+std::shared_ptr<sensor_msgs::msg::Image> mat_to_image(cv::Mat mat);
+
 std::shared_ptr<sensor_msgs::msg::Image> rgb_frame_to_image(libfreenect2::Frame * frame);
 std::shared_ptr<sensor_msgs::msg::Image> ir_frame_to_image(libfreenect2::Frame * frame);
 

--- a/include/kinect2/utility.hpp
+++ b/include/kinect2/utility.hpp
@@ -34,6 +34,7 @@ namespace kinect2
 cv::Mat frame_to_mat(libfreenect2::Frame * frame, const int & type = CV_8UC3);
 std::shared_ptr<sensor_msgs::msg::Image> mat_to_image(cv::Mat mat);
 
+cv::Mat crop_mat(cv::Mat mat, const int & width, const int & height);
 cv::Mat resize_mat(cv::Mat mat, int width, int height);
 
 std::shared_ptr<sensor_msgs::msg::Image> rgb_frame_to_image(

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>libargparse-dev</depend>
   <depend>libfreenect2-dev</depend>
+  <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/src/kinect2.cpp
+++ b/src/kinect2.cpp
@@ -28,7 +28,9 @@ namespace kinect2
 
 Kinect2::Options::Options()
 : enable_rgb(false),
-  enable_depth(false)
+  enable_depth(false),
+  width(-1),
+  height(-1)
 {
 }
 
@@ -49,7 +51,8 @@ unsigned int Kinect2::Options::get_frame_types() const
 
 Kinect2::Kinect2(const Kinect2::Options & options)
 : rclcpp::Node("kinect2", options),
-  SyncMultiFrameListener(options.get_frame_types())
+  SyncMultiFrameListener(options.get_frame_types()),
+  options(options)
 {
   // Check available devices
   if (freenect2.enumerateDevices() <= 0) {
@@ -96,7 +99,7 @@ bool Kinect2::onNewFrame(libfreenect2::Frame::Type type, libfreenect2::Frame * f
   switch (type) {
     case libfreenect2::Frame::Color: {
         if (rgb_image_publisher) {
-          auto color_image = rgb_frame_to_image(frame);
+          auto color_image = rgb_frame_to_image(frame, options.width, options.height);
           rgb_image_publisher->publish(*color_image);
         }
 
@@ -105,7 +108,7 @@ bool Kinect2::onNewFrame(libfreenect2::Frame::Type type, libfreenect2::Frame * f
 
     case libfreenect2::Frame::Ir: {
         if (depth_image_publisher) {
-          auto ir_image = ir_frame_to_image(frame);
+          auto ir_image = ir_frame_to_image(frame, options.width, options.height);
           depth_image_publisher->publish(*ir_image);
         }
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -56,6 +56,17 @@ std::shared_ptr<sensor_msgs::msg::Image> mat_to_image(cv::Mat mat)
   return image;
 }
 
+cv::Mat crop_mat(cv::Mat mat, const int & width, const int & height)
+{
+  cv::Rect roi;
+  roi.x = (mat.cols - width) / 2;
+  roi.y = (mat.rows - height) / 2;
+  roi.width = width;
+  roi.height = height;
+
+  return mat(roi);
+}
+
 cv::Mat resize_mat(cv::Mat mat, int width, int height)
 {
   if (width <= 0 && height <= 0) {
@@ -68,6 +79,13 @@ cv::Mat resize_mat(cv::Mat mat, int width, int height)
 
   if (height <= 0) {
     height = (mat.rows * width) / mat.cols;
+  }
+
+  // Crop image to keep the aspect ratio
+  if (static_cast<double>(width) / height < static_cast<double>(mat.cols) / mat.rows) {
+    mat = crop_mat(mat, (width * mat.rows) / height, mat.rows);
+  } else {
+    mat = crop_mat(mat, mat.cols, (height * mat.cols) / width);
   }
 
   cv::resize(mat, mat, cv::Size(width, height));


### PR DESCRIPTION
- Use [OpenCV](https://opencv.org/) to convert image from Kinect2 to ROS 2.
- Add support to specified published image size.
- Keep aspect ratio (by cropping) when the specified image size has a different aspect ratio with the original image.