### PR TITLE
fix: delete pointers on kinect2 desctruction

### DIFF
--- a/src/kinect2.cpp
+++ b/src/kinect2.cpp
@@ -89,6 +89,12 @@ Kinect2::~Kinect2()
   if (device) {
     device->stop();
     device->close();
+
+    delete device;
+  }
+
+  if (pipeline) {
+    delete pipeline;
   }
 }
 


### PR DESCRIPTION
Delete pointers on `Kinect2` class destructor.